### PR TITLE
Added support for ARM64 and ARMv7 support for Raspberry Pi Testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13.2
+FROM alpine:3.12
 
 RUN apk --no-cache --update add zip openldap openldap-back-mdb openldap-overlay-syncprov openldap-clients
 
@@ -20,6 +20,7 @@ COPY docker-entrypoint.sh slapadd.sh /
 COPY ldap /etc/openldap
 COPY certs /etc/certs
 COPY bin /usr/bin
+RUN chown -R ldap:ldap /etc/openldap
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,6 +13,8 @@ if [ "$1" = 'slapd' ]; then
     chown -R ldap:ldap /var/lib/openldap
   fi
 
+  chown -R ldap:ldap /etc/openldap/slapd.d
+
   if [ ! -f /etc/openldap/slapd.d/cn\=config.ldif ]; then
     [ -d /etc/openldap/slapd.d ] || mkdir /etc/openldap/slapd.d
     . slapadd.sh
@@ -39,3 +41,4 @@ EOF
 fi
 
 exec "$@"
+


### PR DESCRIPTION
Hi, I would like to propose this PR as a feature request in order to support building of the Docker images to support arm64 and armv7 architectures. I have tested this and is working with the images at DCMLinux's Docker hub https://hub.docker.com/u/dcmlinux for all architectures.

In this specific build alpine image had to be downgraded to 3.12 since there is an issue building those images for ARM, slapd would'nt execute correctly due to networking and date issues.